### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/low/easy/relic_bn_shift_low.c
+++ b/src/low/easy/relic_bn_shift_low.c
@@ -109,6 +109,13 @@ dig_t bn_rshb_low(dig_t *c, const dig_t *a, int size, int bits) {
 	int i;
 	dig_t r, carry, shift, mask;
 
+	if (0 == bits) {
+		for (i = 0; i < size; ++i) {
+			c[i] = a[i];
+		}
+		return 0;
+	}
+
 	c += size - 1;
 	a += size - 1;
 	/* Prepare the bit mask. */

--- a/src/relic_util.c
+++ b/src/relic_util.c
@@ -133,6 +133,9 @@ char util_conv_char(dig_t i) {
 }
 
 int util_bits_dig(dig_t a) {
+	if (0 == a) {
+		return 0;
+	}
 #if WORD == 8 || WORD == 16
 	static const uint8_t table[16] = {
 		0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4


### PR DESCRIPTION
Fix for:
- ubsan runtime error: passing zero to clz(), which is not a valid argument
- ubsan runtime error: shift exponent 64 is too large for 64-bit type 'long unsigned int'